### PR TITLE
flatpak-hybris: quote args to fix space issues

### DIFF
--- a/src/flatpak-hybris.sh
+++ b/src/flatpak-hybris.sh
@@ -31,10 +31,11 @@ case "$(dpkg --print-architecture)" in
 		;;
 esac
 
+EXTRA_FLAGS=()
 [ -e /run/user/${UID}/wayland-0 ] && \
-	EXTRA_FLAGS="${EXTRA_FLAGS} --filesystem=/run/user/${UID}/wayland-0:ro"
+	EXTRA_FLAGS+=("--filesystem=/run/user/${UID}/wayland-0:ro")
 [ -e /run/dbus/system_bus_socket ] && \
-	EXTRA_FLAGS="${EXTRA_FLAGS} --filesystem=/run/dbus/system_bus_socket:ro"
+	EXTRA_FLAGS+=("--filesystem=/run/dbus/system_bus_socket:ro")
 
 # Get libdir
 if [ $(getconf LONG_BIT) == 32 ]; then
@@ -78,9 +79,9 @@ if [[ "$@" =~ 'run ' ]]; then
 		--env=HYBRIS_LINKER_DIR=/usr/lib/${TRIPLET}/GL/hybris/${LIBDIR}/libhybris/linker \
 		--env=HYBRIS_LD_LIBRARY_PATH=${HYBRIS_LD_LIBRARY_PATH} \
 		--env=LD_LIBRARY_PATH=/usr/lib/${TRIPLET}/GL/hybris/${LIBDIR}/libhybris-egl:/usr/lib/${TRIPLET}/GL/hybris/${LIBDIR} \
-		${EXTRA_FLAGS} \
-		$@
+		"${EXTRA_FLAGS[@]}" \
+		"${args[@]}"
 else
 	# Pass-through to the real executable
-	exec ${FLATPAK} $@
+	exec "${FLATPAK}" "$@"
 fi


### PR DESCRIPTION
Fixes issues with expanding arguments, resolves the error when trying to use flatpak-builder for example.

Before:
```bash
flatpak-builder --force-clean build-dir io.luigi311.fitness-tracker.yaml --repo=repo --install --user --install-deps-from=flathub --disable-cache
Dependency Sdk: org.gnome.Sdk 48
Updating org.gnome.Sdk/aarch64/48

Nothing to do.
Dependency Runtime: org.gnome.Platform 48
Updating org.gnome.Platform/aarch64/48

Nothing to do.
Emptying app dir 'build-dir'
Downloading sources
Initializing build dir
Committing stage init to cache
Starting build of io.luigi311.fitness-tracker
========================================================================
Building module fitness-tracker in /home/furios/Git/fitness-tracker-flatpak/.flatpak-builder/build/fitness-tracker-5
========================================================================
Running: bsdtar -xf fitness-tracker.deb && tar -xf data.tar.gz
error: Unknown option -pipe
Error: module fitness-tracker: Child process exited with code 1
```

After:
```bash
flatpak-builder --force-clean build-dir io.luigi311.fitness-tracker.yaml --repo=repo --install --user --install-deps-from=flathub --disable-cache
Dependency Sdk: org.gnome.Sdk 48
Updating org.gnome.Sdk/aarch64/48

Nothing to do.
Dependency Runtime: org.gnome.Platform 48
Updating org.gnome.Platform/aarch64/48

Nothing to do.
Emptying app dir 'build-dir'
Downloading sources
Initializing build dir
Committing stage init to cache
Starting build of io.luigi311.fitness-tracker
========================================================================
Building module fitness-tracker in /home/furios/Git/fitness-tracker-flatpak/.flatpak-builder/build/fitness-tracker-6
========================================================================
Running: bsdtar -xf fitness-tracker.deb && tar -xf data.tar.gz
Running: mkdir -p /app/bin
Running: mv usr/bin/fitness-tracker.pex /app/bin/fitness-tracker.pex
Running: install -Dm644 usr/share/icons/hicolor/scalable/apps/fitness-tracker.svg /app/share/icons/hicolor/scalable/apps/io.luigi311.fitness-tracker.svg
Running: desktop-file-edit usr/share/applications/fitness-tracker.desktop --set-icon=io.luigi311.fitness-tracker
Running: install -Dm644 usr/share/applications/fitness-tracker.desktop /app/share/applications/io.luigi311.fitness-tracker.desktop
Running: rm -rf usr data.tar.gz control.tar.gz debian-binary fitness-tracker.deb
Committing stage build-fitness-tracker to cache
Cleaning up
Committing stage cleanup to cache
Finishing app
Exporting share/applications/io.luigi311.fitness-tracker.desktop
Exporting share/icons/hicolor/scalable/apps/io.luigi311.fitness-tracker.svg
Please review the exported files and the metadata
Committing stage finish to cache
Exporting io.luigi311.fitness-tracker to repo
error: /home/furios/Git/fitness-tracker-flatpak/build-dir/export/share/icons/hicolor/scalable/apps/io.luigi311.fitness-tracker.svg is not a valid icon: Error: Unknown option --unshare-ipc

Export failed: Child process exited with code 1
```


That icon validator seems to be a different issue that i cant resolve yet, stubbing out the validator makes the flatpak builder succeed so need to see whats going on with that.