### PR TITLE
Fix for building apps inside Gnome Builder Flatpak

### DIFF
--- a/src/bwrapwrapper.sh
+++ b/src/bwrapwrapper.sh
@@ -4,7 +4,7 @@ BWRAP="/usr/bin/bwrap.real"
 
 # Detect if script is called by completion function
 if [[ "$COMP_LINE" != "" || "$1" == "complete" ]]; then
-        exec "$BWRAP" "$@"
+	exec "$BWRAP" "$@"
 fi
 
 # Handle --args case
@@ -15,6 +15,7 @@ if [[ "$1" == "--args" ]]; then
     readarray -d '' args < /dev/fd/$fd
 else
     args=("$@")
+    set --
 fi
 
 # this seems to be a common issue on arm64. when unsharing pid and user in conjunction it throws an error message.
@@ -26,6 +27,27 @@ for i in "${!args[@]}"; do
             unset 'args[i]'
             ;;
     esac
+done
+
+# Remove --bind/--ro-bind entries that conflict with --ro-bind-data for the same
+# /run/host/ destination. The flatpak-session-helper font forwarding can add these,
+# causing bind mount failures after pivot_root.
+declare -A bind_data_dests
+for (( i=0; i<${#args[@]}; i++ )); do
+    if [[ "${args[i]}" == "--ro-bind-data" ]]; then
+        dest="${args[i+2]}"
+        if [[ "$dest" == /run/host/* ]]; then
+            bind_data_dests["$dest"]=1
+        fi
+    fi
+done
+for i in "${!args[@]}"; do
+    if [[ "${args[i]}" == "--bind" || "${args[i]}" == "--ro-bind" ]]; then
+        dest="${args[i+2]}"
+        if [[ -n "${bind_data_dests[$dest]}" ]]; then
+            unset 'args[i]' 'args[i+1]' 'args[i+2]'
+        fi
+    fi
 done
 
 args=("${args[@]}")


### PR DESCRIPTION
As discussed in the chat, here are the changes to have building apps inside Gnome Builder working and also part of the EGL platform shim fix for the Flutter Flatpaks. I hope, these changes are valid but after testing them on my FLX1s both compiling and building an app inside Gnome Builder Flatpak and launching Fluffychat from Flathub works. 